### PR TITLE
Update installation docs for newer versions of go

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ Later in the week I can update all the repositories which have been cloned, pull
 
 # Installation
 
-You should be able to install this application using the standard golang approach:
+You should be able to install this application using the standard golang approach. For `go>=1.13` go modules must be enabled:
+
+    $ GO111MODULE=on go get github.com/skx/github2mr
+    
+For earlier versions:
 
     $ go get github.com/skx/github2mr
 


### PR DESCRIPTION
As discussed in #4

Ref: https://dev.to/maelvls/why-is-go111module-everywhere-and-everything-about-go-modules-24k#-raw-go111module-endraw-with-go-113