### PR TITLE
Exclude archived repositories by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can run `github2mr -help` to see available options, but in brief:
   * Or the reverse, ignoring all personal-repositories.
 * You can exclude repositories by name.
 * You can default to cloning repositories via HTTP, instead of SSH.
+* By default all _archived_ repositories are excluded.
 
 
 ## Other Git Hosts

--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func main() {
 	//
 	// Parse flags
 	//
+	archived := flag.Bool("archived", false, "Include archived repositories in the output?")
 	api := flag.String("api", "https://api.github.com/", "The API end-point to use for the remote git-host.")
 	authHeader := flag.Bool("auth-header-token", false, "Use an authorization-header including 'token' rather than 'bearer'.\nThis is required for gitbucket, and perhaps other systems.")
 	exclude := flag.String("exclude", "", "Comma-separated list of repositories to exclude.")
@@ -359,6 +360,15 @@ func main() {
 	// Now format the repositories we've discovered.
 	//
 	for _, repo := range all {
+
+		//
+		// If the repository is archived then
+		// skip it, unless we're supposed to keep
+		// it.
+		//
+		if *repo.Archived && !*archived {
+			continue
+		}
 
 		//
 		// The clone-type is configurable


### PR DESCRIPTION
This closes #6, by excluding archived repositories unless `-archived=true` is specified.

This seems like a sane enough default.